### PR TITLE
feat: add nix flake metadata command

### DIFF
--- a/crates/runix/src/flake_ref.rs
+++ b/crates/runix/src/flake_ref.rs
@@ -72,13 +72,13 @@ pub enum ToFlakeRef {
         all_refs: Option<bool>,
 
         #[serde(rename = "ref")]
-        commit_ref: CommitRef,
+        commit_ref: Option<CommitRef>,
 
         #[serde(rename = "revCount")]
         rev_count: Option<RevCount>,
 
         #[serde(flatten)]
-        pinned: Pinned,
+        pinned: Option<Pinned>,
     },
     /// https://cs.github.com/NixOS/nix/blob/f225f4307662fe9a57543d0c86c28aa9fddaf0d2/src/libfetchers/tarball.cc#L206
     Tarball {


### PR DESCRIPTION
Hello, saw your talk at FOSDEM :100: 

this simply adds support for `nix flake metadata` to runix, the only non-trivial thing is that it makes `Git`s `pinned` and `ref` in `ToFlakeRef` optional in order to support locally checked out flakes:
```
nix flake metadata --json | jq '.locked'  
{
  "lastModified": 0,
  "narHash": "sha256-UseRluAkdnsnMNNfX9o4QzdQIhYVv9ssNpyhU5ZnBRI=",
  "type": "git",
  "url": "file:///home/phaer/src/runix"
}
```

The alternative I see would be to use a separate type for things like `locked`, `original` and `resolved` even though they are technically flake references.