### PR TITLE
feat: add conversions from/to iterator for `Registry`

### DIFF
--- a/crates/runix/src/registry.rs
+++ b/crates/runix/src/registry.rs
@@ -48,6 +48,15 @@ impl Registry {
     }
 }
 
+impl FromIterator<RegistryEntry> for Registry {
+    fn from_iter<T: IntoIterator<Item = RegistryEntry>>(iter: T) -> Self {
+        Self {
+            version: Version::default(),
+            flakes: BTreeSet::from_iter(iter),
+        }
+    }
+}
+
 /// TODO: use https://github.com/dtolnay/serde-repr?
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 struct Version(u8);

--- a/crates/runix/src/registry.rs
+++ b/crates/runix/src/registry.rs
@@ -41,6 +41,11 @@ impl Registry {
     #[allow(unused)]
     /// Todo: more functions such as remove, get, etc
     pub fn remove(&mut self, _name: impl ToString) {}
+
+    /// Iterate over the entries in the registry
+    pub fn entries(&self) -> impl Iterator<Item = &RegistryEntry> {
+        self.flakes.iter()
+    }
 }
 
 /// TODO: use https://github.com/dtolnay/serde-repr?
@@ -54,10 +59,10 @@ impl Default for Version {
 
 #[skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-struct RegistryEntry {
-    from: IndirectRef, // TODO merge into single flakeRef type @notgne2?
-    to: FlakeRef,
-    exact: Option<bool>,
+pub struct RegistryEntry {
+    pub from: IndirectRef, // TODO merge into single flakeRef type @notgne2?
+    pub to: FlakeRef,
+    pub exact: Option<bool>,
 }
 
 impl Ord for RegistryEntry {


### PR DESCRIPTION
The registry model is currently quite encapsulated.
Open enough to add entries and (de)serialize but doesn't allow much else.
This PR adds the capability to list registry entries and build a registry from entries in bulk.