### PR TITLE
refactor!: implement a stricter version of installable

### DIFF
--- a/crates/runix/Cargo.toml
+++ b/crates/runix/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0"
 serde_with = "2.2.0"
 serde_urlencoded = "0.7.1"
 url = { version = "2.3", features = ["serde"] }
+percent-encoding = "2.2"
 shell-escape = "0.1.5"
 tokio = { version = "1.21", features = ["full"] }
 tokio-stream = { version = "0.1.11", features = ["tokio-util", "io-util"] }

--- a/crates/runix/src/arguments/flake.rs
+++ b/crates/runix/src/arguments/flake.rs
@@ -5,7 +5,7 @@ use runix_derive::ToArgs;
 
 use crate::command_line::flag::{Flag, FlagType};
 use crate::command_line::ToArgs;
-use crate::installable::FlakeRef;
+use crate::flake_ref::FlakeRef;
 
 /// Flake related arguments
 /// Corresponding to the arguments defined in
@@ -19,7 +19,7 @@ pub struct FlakeArgs {
 /// Tuple like override inputs flag
 #[derive(Clone, Debug, From, Constructor)]
 pub struct OverrideInput {
-    pub from: FlakeRef,
+    pub from: String,
     pub to: FlakeRef,
 }
 impl Flag for OverrideInput {
@@ -28,7 +28,7 @@ impl Flag for OverrideInput {
 }
 impl OverrideInput {
     fn args(&self) -> Vec<String> {
-        vec![self.from.clone(), self.to.clone()]
+        vec![self.from.to_string(), self.to.to_string()]
     }
 }
 

--- a/crates/runix/src/arguments/mod.rs
+++ b/crates/runix/src/arguments/mod.rs
@@ -49,7 +49,7 @@ impl ToArgs for NixArgs {
 pub struct InstallableArg(Option<Installable>);
 impl ToArgs for InstallableArg {
     fn to_args(&self) -> Vec<String> {
-        self.0.iter().map(|i| i.to_nix()).collect()
+        self.0.iter().map(|i| i.to_string()).collect()
     }
 }
 
@@ -60,7 +60,7 @@ impl ToArgs for InstallableArg {
 pub struct InstallablesArgs(Vec<Installable>);
 impl ToArgs for InstallablesArgs {
     fn to_args(&self) -> Vec<String> {
-        self.0.iter().map(|i| i.to_nix()).collect()
+        self.0.iter().map(|i| i.to_string()).collect()
     }
 }
 

--- a/crates/runix/src/command_line/mod.rs
+++ b/crates/runix/src/command_line/mod.rs
@@ -15,7 +15,6 @@ use serde_json::Value;
 use thiserror::Error;
 use tokio::process::Command;
 
-
 use crate::arguments::common::NixCommonArgs;
 use crate::arguments::config::NixConfigArgs;
 use crate::arguments::eval::EvaluationArgs;
@@ -153,7 +152,10 @@ impl CommandMode for Collect {
 
         let child = command.spawn().map_err(NixCommandLineError::Run)?;
 
-        let output = child.wait_with_output().await.map_err(NixCommandLineError::Run)?;
+        let output = child
+            .wait_with_output()
+            .await
+            .map_err(NixCommandLineError::Run)?;
 
         if !output.status.success() {
             return Err(NixCommandLineCollectError::NixError(output.status));

--- a/crates/runix/src/installable.rs
+++ b/crates/runix/src/installable.rs
@@ -133,7 +133,6 @@ impl FromStr for Attribute {
     type Err = ParseInstallableError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        dbg!(s);
         if !(VALID_ATTRIBUTE.is_match(s)) {
             Err(ParseInstallableError::InvalidAttr(s.to_string()))?;
         }
@@ -199,7 +198,7 @@ mod tests {
 
     #[test]
     fn attr_path_from_str() {
-        "a".parse::<AttrPath>().expect("should single attribute");
+        "a".parse::<AttrPath>().expect("should parse single attribute");
         "a.b.c"
             .parse::<AttrPath>()
             .expect("should parse nested path");
@@ -218,10 +217,10 @@ mod tests {
             .expect_err("should not parse with interpolation");
         "a.\"${\"asdf\"}\".c"
             .parse::<AttrPath>()
-            .expect_err("should parse with interpolation that interpolates a string");
+            .expect_err("should not parse with interpolation that interpolates a string");
         "\"${asdf}\".c"
             .parse::<AttrPath>()
-            .expect_err("should parse with interpolation in the front");
+            .expect_err("should not parse with interpolation in the front");
         "x.${asdf}.c"
             .parse::<AttrPath>()
             .expect_err("should not parse with dynamic element");
@@ -244,7 +243,7 @@ mod tests {
         AttrPath::try_from(["a", "b", "c"]).expect("should parse nested path");
         AttrPath::try_from(["a", "${asdf}", "c"]).expect_err("should not parse with interpolation");
         AttrPath::try_from(["\"${asdf}\"", ".c"])
-            .expect_err("should parse with interpolation in the front");
+            .expect_err("should not parse with interpolation in the front");
         AttrPath::try_from(["x.${asdf}", "c"]).expect_err("should not parse with dynamic element");
 
         dbg!(AttrPath::try_from(["a", "b", "c"])

--- a/crates/runix/src/installable.rs
+++ b/crates/runix/src/installable.rs
@@ -13,6 +13,12 @@ use crate::flake_ref::{FlakeRef, ParseFlakeRefError};
 /// regex listing valid characters for attributes
 ///
 /// derived from https://github.com/NixOS/nix/blob/master/src/libutil/url-parts.hh
+///
+/// A valid attribute is almost any valid (string) attribute name in the nix language.
+/// As most characters can be used in an attribute name as long as its quoted,
+/// more than just alphanumerics can be used.
+/// However, `{}` and `[]` are disallowed, the former, presumably due to `${...}`
+/// being used as string substitution in the nix language.
 static VALID_ATTRIBUTE: Lazy<Regex> =
     Lazy::new(|| Regex::new("^([a-zA-Z0-9-._~!$&'()*+,;=:%@?/ ]*)$").unwrap());
 

--- a/crates/runix/src/installable.rs
+++ b/crates/runix/src/installable.rs
@@ -44,6 +44,9 @@ pub struct AttrPath(Vec<Attribute>);
 
 impl AttrPath {
     /// Add another component to the end of the attrpath
+    ///
+    /// Unlike parsing an attrpath from string,
+    /// this will not perform any percent decoding
     pub fn push_attr(&mut self, attr: &str) -> Result<&mut Self, <Attribute as FromStr>::Err> {
         self.0.push(attr.parse::<Attribute>()?);
         Ok(self)
@@ -74,6 +77,9 @@ impl FromIterator<Attribute> for AttrPath {
 impl FromStr for AttrPath {
     type Err = ParseInstallableError;
 
+    /// parse attr path string
+    ///
+    /// **Note**: percent decodes the input
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = percent_encoding::percent_decode_str(s).decode_utf8()?;
 
@@ -105,6 +111,9 @@ impl FromStr for AttrPath {
 }
 
 impl Display for AttrPath {
+    /// formats attr path string
+    ///
+    /// **Note**: percent encodes the output
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (n, attr) in self.iter().enumerate() {
             if n > 0 {

--- a/crates/runix/src/installable.rs
+++ b/crates/runix/src/installable.rs
@@ -240,7 +240,7 @@ mod tests {
         assert_eq!(output.to_string(), input);
     }
 
-    fn assert_parse_compontents<'a>(
+    fn assert_parse_components<'a>(
         components: impl AsRef<[&'a str]>,
         expect: &str,
         description: &str,
@@ -272,10 +272,10 @@ mod tests {
 
     #[test]
     fn attr_path_from_list() {
-        assert_parse_compontents(["a"], "a", "parse single attribute");
-        assert_parse_compontents([""], "", "parse empty");
-        assert_parse_compontents(["a", "b", "c"], "a.b.c", "parse nested path");
-        assert_parse_compontents(["a.b"], "\"a.b\"", "should parse quoted single attribute");
+        assert_parse_components(["a"], "a", "parse single attribute");
+        assert_parse_components([""], "", "parse empty");
+        assert_parse_components(["a", "b", "c"], "a.b.c", "parse nested path");
+        assert_parse_components(["a.b"], "\"a.b\"", "should parse quoted single attribute");
 
         AttrPath::try_from(["a", "${asdf}", "c"]).expect_err("should not parse with interpolation");
         AttrPath::try_from(["\"${asdf}\"", ".c"])

--- a/crates/runix/src/installable.rs
+++ b/crates/runix/src/installable.rs
@@ -3,6 +3,7 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
+use derive_more::{AsRef, IntoIterator};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use thiserror::Error;
@@ -38,7 +39,7 @@ pub struct Installable {
 /// AttrPath::try_from(["abc", "xyz"]).expect("Parses from array");
 /// AttrPath::try_from(&*vec!["abc", "xyz"]).expect("Parses from vec");
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, IntoIterator)]
 pub struct AttrPath(Vec<Attribute>);
 
 impl AttrPath {
@@ -49,13 +50,24 @@ impl AttrPath {
     }
 
     /// get an iterator over all components of the attrpath
-    pub fn components(&self) -> impl Iterator<Item = &Attribute> {
+    pub fn iter(&self) -> impl Iterator<Item = &Attribute> {
         self.0.iter()
+    }
+
+    /// get an iterator over all components of the attrpath and allow modification
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Attribute> {
+        self.0.iter_mut()
     }
 
     /// determine whether the attrpath is empty
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+}
+
+impl FromIterator<Attribute> for AttrPath {
+    fn from_iter<T: IntoIterator<Item = Attribute>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
     }
 }
 
@@ -94,7 +106,7 @@ impl FromStr for AttrPath {
 
 impl Display for AttrPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (n, attr) in self.0.iter().enumerate() {
+        for (n, attr) in self.iter().enumerate() {
             if n > 0 {
                 write!(f, ".")?;
             }
@@ -134,7 +146,7 @@ impl<A: AsRef<str>, const N: usize> TryFrom<[A; N]> for AttrPath {
 /// A validated attribute
 ///
 /// Component of an attrpath
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, AsRef)]
 pub struct Attribute(String);
 
 impl FromStr for Attribute {

--- a/crates/runix/src/installable.rs
+++ b/crates/runix/src/installable.rs
@@ -3,15 +3,152 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
+use once_cell::sync::Lazy;
+use regex::Regex;
 use thiserror::Error;
 
 use crate::flake_ref::{FlakeRef, ParseFlakeRefError};
+
+/// regex describing valid characters for attributes
+/// derived from <https://github.com/flox/nix/blob/ysndr/disable_attrpath_resolution/src/libutil/url-parts.hh#L21>
+static VALID_ATTRIBUTE: Lazy<Regex> =
+    Lazy::new(|| Regex::new("^([a-zA-Z0-9-._~!$&'()*+,;=:@?/ ]*)$").unwrap());
 
 /// A simplified installable representation
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Installable {
     pub flakeref: FlakeRef,
-    pub attr_path: Vec<String>,
+    pub attr_path: AttrPath,
+}
+
+/// The attrpath component of an installable
+///
+/// This implementation wraps a [Vec<String>] for components.
+/// Its [FromStr] and [Display] implementations are used to parse and validate,
+/// as well as canonically print an attrpath.
+///
+/// The implementation also includes [TryFrom] implementations to allow
+/// ergonomic validated conversion from list types
+///
+/// ```
+/// use runix::installable::AttrPath;
+///
+/// "abc.xyz".parse::<AttrPath>().expect("Parses from String");
+/// AttrPath::try_from(["abc", "xyz"]).expect("Parses from array");
+/// AttrPath::try_from(&*vec!["abc", "xyz"]).expect("Parses from vec");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AttrPath(Vec<Attribute>);
+
+impl AttrPath {
+    /// Add another component to the end of the attrpath
+    pub fn push_attr(&mut self, attr: &str) -> Result<&mut Self, <Attribute as FromStr>::Err> {
+        self.0.push(attr.parse::<Attribute>()?);
+        Ok(self)
+    }
+
+    /// get an iterator over all components of the attrpath
+    pub fn components(&self) -> impl Iterator<Item = &Attribute> {
+        self.0.iter()
+    }
+
+    /// determine whether the attrpath is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl FromStr for AttrPath {
+    type Err = ParseInstallableError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut attributes = AttrPath::default();
+        let mut cur = String::new();
+
+        let mut start_quote = None;
+
+        for (n, c) in s.chars().enumerate() {
+            match c {
+                '.' if start_quote.is_none() => {
+                    attributes.push_attr(&std::mem::take(&mut cur))?;
+                },
+                '"' if start_quote.is_some() => start_quote = None,
+                '"' if start_quote.is_none() => start_quote = Some(n),
+                other => cur.push(other),
+            }
+        }
+
+        if let Some(start) = start_quote {
+            return Err(ParseInstallableError::UnclosedQuote(
+                s.to_string().split_off(start),
+            ));
+        }
+
+        if !cur.is_empty() {
+            attributes.push_attr(&cur)?;
+        }
+        Ok(attributes)
+    }
+}
+
+impl Display for AttrPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some((first, rest)) = self.0.split_first() {
+            write!(f, "{first}")?;
+            for attr in rest {
+                write!(f, ".{attr}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<A: AsRef<str>> TryFrom<&[A]> for AttrPath {
+    type Error = ParseInstallableError;
+
+    fn try_from(value: &[A]) -> Result<Self, Self::Error> {
+        value
+            .iter()
+            .map(|a| a.as_ref().parse())
+            .collect::<Result<_, _>>()
+            .map(Self)
+    }
+}
+
+impl<A: AsRef<str>, const N: usize> TryFrom<[A; N]> for AttrPath {
+    type Error = ParseInstallableError;
+
+    fn try_from(value: [A; N]) -> Result<Self, Self::Error> {
+        value.as_slice().try_into()
+    }
+}
+
+/// A validated attribute
+///
+/// Component of an attrpath
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Attribute(String);
+
+impl FromStr for Attribute {
+    type Err = ParseInstallableError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        dbg!(s);
+        if !(VALID_ATTRIBUTE.is_match(s)) {
+            Err(ParseInstallableError::InvalidAttr(s.to_string()))?;
+        }
+        Ok(Attribute(s.to_string()))
+    }
+}
+
+impl Display for Attribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.contains('.') {
+            write!(f, "\"{}\"", self.0)
+        } else {
+            write!(f, "{}", self.0)
+        }
+    }
 }
 
 impl FromStr for Installable {
@@ -21,16 +158,23 @@ impl FromStr for Installable {
         match s.split_once('#') {
             Some((flakeref, attr_path)) => Ok(Installable {
                 flakeref: flakeref.parse()?,
-                attr_path: attr_path.split('.').map(String::from).collect(),
+                attr_path: attr_path.parse()?,
             }),
-            None => Err(ParseInstallableError::MissingAttrPath),
+            None => Ok(Installable {
+                flakeref: s.parse()?,
+                attr_path: "".parse()?,
+            }),
         }
     }
 }
 
 impl Display for Installable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}#{}", self.flakeref, self.attr_path.join("."))
+        write!(f, "{}", self.flakeref)?;
+        if !self.attr_path.is_empty() {
+            write!(f, "#{}", self.attr_path)?;
+        }
+        Ok(())
     }
 }
 
@@ -40,4 +184,79 @@ pub enum ParseInstallableError {
     ParseFlakeRef(#[from] ParseFlakeRefError),
     #[error("Installable is missing an attribute path")]
     MissingAttrPath,
+    #[error(
+        "Missing closing quote in selection path: '
+    {0}'"
+    )]
+    UnclosedQuote(String),
+    #[error("Invalid attribute '{0}'")]
+    InvalidAttr(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attr_path_from_str() {
+        "a".parse::<AttrPath>().expect("should single attribute");
+        "a.b.c"
+            .parse::<AttrPath>()
+            .expect("should parse nested path");
+        "\"a\""
+            .parse::<AttrPath>()
+            .expect("should parse quoted single");
+
+        "''a''"
+            .parse::<AttrPath>()
+            .expect("should parse '' quoted single");
+        "\"${abc}\""
+            .parse::<AttrPath>()
+            .expect_err("should not parse just interpolated");
+        "a.\"${asdf}\".c"
+            .parse::<AttrPath>()
+            .expect_err("should not parse with interpolation");
+        "a.\"${\"asdf\"}\".c"
+            .parse::<AttrPath>()
+            .expect_err("should parse with interpolation that interpolates a string");
+        "\"${asdf}\".c"
+            .parse::<AttrPath>()
+            .expect_err("should parse with interpolation in the front");
+        "x.${asdf}.c"
+            .parse::<AttrPath>()
+            .expect_err("should not parse with dynamic element");
+
+        "x.\"open.no.close"
+            .parse::<AttrPath>()
+            .expect_err("should detect unclosed");
+
+        "2".parse::<AttrPath>().expect("should parse number");
+        "\"2\""
+            .parse::<AttrPath>()
+            .expect("should parse quoted number");
+    }
+
+    #[test]
+    fn attr_path_from_list() {
+        AttrPath::try_from(["a"]).expect("should parse single attribute");
+        AttrPath::try_from([""]).expect("should parse single attribute");
+        AttrPath::try_from(["a.b"]).expect("should parse quoted single attribute");
+        AttrPath::try_from(["a", "b", "c"]).expect("should parse nested path");
+        AttrPath::try_from(["a", "${asdf}", "c"]).expect_err("should not parse with interpolation");
+        AttrPath::try_from(["\"${asdf}\"", ".c"])
+            .expect_err("should parse with interpolation in the front");
+        AttrPath::try_from(["x.${asdf}", "c"]).expect_err("should not parse with dynamic element");
+
+        dbg!(AttrPath::try_from(["a", "b", "c"])
+            .unwrap()
+            .components()
+            .collect::<Vec<_>>());
+
+        println!("{}", AttrPath::try_from(["a", "b", "c"]).unwrap());
+
+        println!(
+            "{}",
+            AttrPath::try_from(["a(.)"]).expect("should parse single attribute")
+        );
+    }
 }

--- a/crates/runix/src/installable.rs
+++ b/crates/runix/src/installable.rs
@@ -74,6 +74,12 @@ impl FromIterator<Attribute> for AttrPath {
     }
 }
 
+impl<'a> FromIterator<&'a Attribute> for AttrPath {
+    fn from_iter<T: IntoIterator<Item = &'a Attribute>>(iter: T) -> Self {
+        Self(iter.into_iter().cloned().collect())
+    }
+}
+
 impl FromStr for AttrPath {
     type Err = ParseInstallableError;
 


### PR DESCRIPTION
Installables attrpaths should be manageable as individual elements.
We want to manipulate individual elements and not guess about escaping.
Similarly strings should be parsed correctly into attrpaths.

Implementing it here also allows better errors compared to nix.

where nix will return

```
error: '.#he\\o.world' is not a valid URL
```

we can now return errors on a per attribute basis:

```
Invalid attribute 'he\\o'
```
