### PR TITLE
chore: flakebump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,16 @@
   "nodes": {
     "builtfilter": {
       "inputs": {
-        "capacitor": [
-          "flox-floxpkgs",
-          "capacitor"
+        "flox-floxpkgs": [
+          "flox-floxpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1661869301,
-        "narHash": "sha256-LcOkB1sYNCiw0rfDR09TS4v5a2p8wm4yIBPBeuZCIu4=",
+        "lastModified": 1679586988,
+        "narHash": "sha256-TkoF4E4yN40s042YG6DaOzk+vtbzsoey0lUO+tm03is=",
         "owner": "flox",
         "repo": "builtfilter",
-        "rev": "a37cb0fb1dfb752101eb2936099530872c07c956",
+        "rev": "931a381bb96d909f51fcf25d7ca4fa9dcfb12aff",
         "type": "github"
       },
       "original": {
@@ -82,6 +81,38 @@
         "type": "github"
       }
     },
+    "commitizen-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1679149521,
+        "narHash": "sha256-F/fbBEwG7ijHELy4RnpvlXOPkTsXFxjALdK7UIGIzMo=",
+        "owner": "commitizen-tools",
+        "repo": "commitizen",
+        "rev": "378a42881891633d8a81939cb46426eb36ed01aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "commitizen-tools",
+        "repo": "commitizen",
+        "type": "github"
+      }
+    },
+    "commitizen-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678272786,
+        "narHash": "sha256-ISjw9OH27XLYCYG2oLTbWN2eNQGGii92Ex7M7ynJjrE=",
+        "owner": "commitizen-tools",
+        "repo": "commitizen",
+        "rev": "fb0d1ebacb29b3ca0ea33a349dbb8064ae6c72fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "commitizen-tools",
+        "repo": "commitizen",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -99,6 +130,22 @@
       }
     },
     "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1673956053,
@@ -144,8 +191,24 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flox": {
       "inputs": {
+        "commitizen-src": "commitizen-src",
         "flox-bash": [
           "flox-floxpkgs",
           "flox-bash"
@@ -156,11 +219,11 @@
         "shellHooks": "shellHooks"
       },
       "locked": {
-        "lastModified": 1675525395,
-        "narHash": "sha256-qTEZIslIq6LG3qPBTV9uLTORFWFmwB9PrDFQgBty+ek=",
+        "lastModified": 1680803669,
+        "narHash": "sha256-rIE8EMohgBH6fIr7r39KpD2wV3pIYbl25BQo1nVPYd4=",
         "ref": "main",
-        "rev": "2770f59526f0c2583bfe56724505770f849d49a1",
-        "revCount": 351,
+        "rev": "0821da032f3e8b05d667695f7f6a2d45ce83a08a",
+        "revCount": 437,
         "type": "git",
         "url": "ssh://git@github.com/flox/flox"
       },
@@ -172,16 +235,17 @@
     },
     "flox-bash": {
       "inputs": {
+        "flox": "flox_2",
         "flox-floxpkgs": [
           "flox-floxpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1675514010,
-        "narHash": "sha256-SsrKMU5UfelpwzAJJZKsrmHiND/XhBWarxPe/httdOg=",
+        "lastModified": 1680721691,
+        "narHash": "sha256-RV5b0EUsHdHvae3mTGK+/wfq6c5IqGAJuUS0fVlscJ4=",
         "ref": "main",
-        "rev": "0c09600667333ebedf79691926ff182e83749015",
-        "revCount": 184,
+        "rev": "9f2d13881a05ad5f2b76d3f40f8947a5e5750f89",
+        "revCount": 219,
         "type": "git",
         "url": "ssh://git@github.com/flox/flox-bash"
       },
@@ -198,20 +262,48 @@
         "catalog": "catalog",
         "flox": "flox",
         "flox-bash": "flox-bash",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "tracelinks": "tracelinks"
       },
       "locked": {
-        "lastModified": 1675597308,
-        "narHash": "sha256-dl1ENSa5Sp1y/8d/yxN1VmQWdbXjoR7peBSOjqHgBDA=",
+        "lastModified": 1681747047,
+        "narHash": "sha256-YhSFKQ4xI67jRUHVqjcH5uUPsJ+FPeO6SVBdMQ4Apdk=",
         "owner": "flox",
         "repo": "floxpkgs",
-        "rev": "76b86c2e8dfb331579227d36ba8f45d13ce6eaea",
+        "rev": "c1c22db8cbcf9297ed28b99e0b8ed25f07b4fd96",
         "type": "github"
       },
       "original": {
         "owner": "flox",
         "repo": "floxpkgs",
+        "type": "github"
+      }
+    },
+    "flox_2": {
+      "inputs": {
+        "commitizen-src": "commitizen-src_2",
+        "flox-bash": [
+          "flox-floxpkgs",
+          "flox-bash"
+        ],
+        "flox-floxpkgs": [
+          "flox-floxpkgs",
+          "flox-bash",
+          "flox-floxpkgs"
+        ],
+        "shellHooks": "shellHooks_2"
+      },
+      "locked": {
+        "lastModified": 1678377522,
+        "narHash": "sha256-Mkcp2vUAJnMpqe/ofUPJVzeLbNnWjrQUNPECXGmT4S4=",
+        "owner": "flox",
+        "repo": "flox",
+        "rev": "90fabfee9d0b19e33da6bc5a4376e382e27f658e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "flox",
         "type": "github"
       }
     },
@@ -241,6 +333,30 @@
     "gitignore_2": {
       "inputs": {
         "nixpkgs": [
+          "flox-floxpkgs",
+          "flox-bash",
+          "flox",
+          "shellHooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_3": {
+      "inputs": {
+        "nixpkgs": [
           "shellHooks",
           "nixpkgs"
         ]
@@ -261,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674459583,
-        "narHash": "sha256-L0UZl/u2H3HGsrhN+by42c5kNYeKtdmJiPzIRvEVeiM=",
+        "lastModified": 1679262748,
+        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
+        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
         "type": "github"
       },
       "original": {
@@ -277,11 +393,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1675558495,
-        "narHash": "sha256-7jwOfNefWeqUk5i8yOVRWrm4klglVOubtGXU11ZId2o=",
+        "lastModified": 1681001314,
+        "narHash": "sha256-5sDnCLdrKZqxLPK4KA8+f4A3YKO/u6ElpMILvX0g72c=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c8c50fd1c544dad4f590c3b91c5d65c5ba6aff77",
+        "rev": "367c0e1086a4eb4502b24d872cea2c7acdd557f4",
         "type": "github"
       },
       "original": {
@@ -292,11 +408,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1674953599,
-        "narHash": "sha256-DlAzFbth2P6Hp1M7smDd1apa2dJdxw3FeaWpl03LWeU=",
+        "lastModified": 1681001314,
+        "narHash": "sha256-5sDnCLdrKZqxLPK4KA8+f4A3YKO/u6ElpMILvX0g72c=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a6486be6c11c609cd60c01a427279e8a80a025fa",
+        "rev": "367c0e1086a4eb4502b24d872cea2c7acdd557f4",
         "type": "github"
       },
       "original": {
@@ -306,6 +422,22 @@
       }
     },
     "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
       "locked": {
         "lastModified": 1673800717,
         "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
@@ -321,13 +453,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable_2": {
+    "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1671983799,
-        "narHash": "sha256-Z2Ro6hFPZHkBqkVXY5/aBUzxi5xizQGvuHQ9+T5B/ks=",
+        "lastModified": 1679262748,
+        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "fad51abd42ca17a60fc1d4cb9382e2d79ae31836",
+        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
         "type": "github"
       },
       "original": {
@@ -339,11 +471,11 @@
     },
     "nixpkgs-staging": {
       "locked": {
-        "lastModified": 1674459583,
-        "narHash": "sha256-L0UZl/u2H3HGsrhN+by42c5kNYeKtdmJiPzIRvEVeiM=",
+        "lastModified": 1680487167,
+        "narHash": "sha256-9FNIqrxDZgSliGGN2XJJSvcDYmQbgOANaZA4UWnTdg4=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
+        "rev": "53dad94e874c9586e71decf82d972dfb640ef044",
         "type": "github"
       },
       "original": {
@@ -355,11 +487,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1674641431,
-        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
+        "lastModified": 1681036984,
+        "narHash": "sha256-AbScJXshYzbeUKHh+Y3OICc3iAtr+NqJ3Xb81GW+ptU=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
+        "rev": "fd531dee22c9a3d4336cc2da39e8dd905e8f3de4",
         "type": "github"
       },
       "original": {
@@ -370,6 +502,22 @@
       }
     },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1678898370,
+        "narHash": "sha256-xTICr1j+uat5hk9FyuPOFGxpWHdJRibwZC+ATi0RbtE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac718d02867a84b42522a0ece52d841188208f2c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1671271357,
         "narHash": "sha256-xRJdLbWK4v2SewmSStYrcLa0YGJpleufl44A19XSW8k=",
@@ -385,7 +533,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "inputs": {
         "capacitor": "capacitor_2",
         "flox": [
@@ -399,12 +547,8 @@
         "flox-floxpkgs": [
           "flox-floxpkgs"
         ],
-        "nixpkgs": [
-          "flox-floxpkgs",
-          "nixpkgs",
-          "nixpkgs-stable"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable_2",
+        "nixpkgs": "nixpkgs_5",
+        "nixpkgs-stable": "nixpkgs-stable_3",
         "nixpkgs-staging": "nixpkgs-staging",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nixpkgs__flox__aarch64-darwin": "nixpkgs__flox__aarch64-darwin",
@@ -414,11 +558,11 @@
         "nixpkgs__flox__x86_64-linux": "nixpkgs__flox__x86_64-linux"
       },
       "locked": {
-        "lastModified": 1675117426,
-        "narHash": "sha256-zrSqcqWaFbJXnUKgFlIrNg6/73DAgdWr75UoxjTDrRo=",
+        "lastModified": 1681168903,
+        "narHash": "sha256-R1lPeByrRz4Tv7DJXrs5FwWxv/Z4HGl+4gIGjEeIZwg=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "bc44d6d77530ff0f5d7cdf28b4d8feb37bc8af70",
+        "rev": "ef0aa65607c800694e2e22e04e5f1c5926003d77",
         "type": "github"
       },
       "original": {
@@ -427,15 +571,29 @@
         "type": "github"
       }
     },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1679262748,
+        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs-stable",
+        "type": "indirect"
+      }
+    },
     "nixpkgs__flox__aarch64-darwin": {
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1675107732,
-        "narHash": "sha256-jKctlxsXMgxzSV7THZcN4s1oIDf39saRCoMQ7DBIWTo=",
+        "lastModified": 1681168725,
+        "narHash": "sha256-bOKjrTggB+rWD3CQujLgH9/yLr59uow19/NTZW/O7ag=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "170f500c77984dda06846d47efe44990023d30b1",
+        "rev": "df6f390a6311f5936389647865495b8b9ef5a6fb",
         "type": "github"
       },
       "original": {
@@ -450,11 +608,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1675107716,
-        "narHash": "sha256-9vzgSX6ESPsqMPaSSMSWJqsFOq6AvDQgL84tDFCiv+A=",
+        "lastModified": 1681168706,
+        "narHash": "sha256-5xt70PSIK6/JW8vkYvD0WaBCEojCvWB7x9SDsY8QS/0=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "9c56e6ff1169d268d45b0071982d4094f0db953c",
+        "rev": "1f79e30f73a6625725c72ca3174ab7e737cee0a9",
         "type": "github"
       },
       "original": {
@@ -469,11 +627,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1675107834,
-        "narHash": "sha256-wPiaSntujDHzJgTDb1d3Uv1pVePyW1kQNG05M9gOUjM=",
+        "lastModified": 1680978945,
+        "narHash": "sha256-Qu4al3Eichv5O6ZkjLsdfV7+GUIgSs9ye8QdnkqzYMw=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "ea7a0479a45597c6c5c97d73e8cc76057c9124d0",
+        "rev": "6c5e6aeb86ef698be7e4d1046a25a8cb37089722",
         "type": "github"
       },
       "original": {
@@ -488,11 +646,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1675107826,
-        "narHash": "sha256-7QrCrtw36223WtDHPYsvCN331VS7xGfOFGWaRhLRHGc=",
+        "lastModified": 1680978937,
+        "narHash": "sha256-CxNW9LWMKaGTgblsBbKDTEFe2BhjXuAPIUxXE0iAcK0=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "5f174893aef5ab34f6cd1b87eeffa80b8bf81fe6",
+        "rev": "9f74bc069f6c31b97a8207d7a8e4aedc932190d4",
         "type": "github"
       },
       "original": {
@@ -507,11 +665,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1673555550,
-        "narHash": "sha256-11+5aS8Q15cz6U4cgsWf/gA4QFSo5cdsbqc5J2RKQJE=",
+        "lastModified": 1681168786,
+        "narHash": "sha256-UKlBamyKikQbaTTrH8UDhh7PCFN5CX0eQmKrhES69pU=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "d38ddf9c20aa652cf66069c71c85c9cb2b49461f",
+        "rev": "16a1426c4fb49594883d539ec1a1fd26ca43f07f",
         "type": "github"
       },
       "original": {
@@ -530,7 +688,7 @@
           "nixpkgs",
           "nixpkgs"
         ],
-        "shellHooks": "shellHooks_2"
+        "shellHooks": "shellHooks_3"
       }
     },
     "shellHooks": {
@@ -542,11 +700,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1675169698,
-        "narHash": "sha256-C1wFiyJ+4SRvIsFkdMIN1Fa+58APmyTGKWpX9EKOehM=",
+        "lastModified": 1678976941,
+        "narHash": "sha256-skNr08frCwN9NO+7I77MjOHHAw+L410/37JknNld+W4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ce4efeec34c6eb35ba07b8fceaae87d6b46c1c5f",
+        "rev": "32b1dbedfd77892a6e375737ef04d8efba634e9e",
         "type": "github"
       },
       "original": {
@@ -560,6 +718,28 @@
         "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils_2",
         "gitignore": "gitignore_2",
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-stable": "nixpkgs-stable_2"
+      },
+      "locked": {
+        "lastModified": 1677832802,
+        "narHash": "sha256-XQf+k6mBYTiQUjWRf/0fozy5InAs03O1b30adCpWeXs=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "382bee738397ca005206eefa36922cc10df8a21c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "shellHooks_3": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_3",
+        "gitignore": "gitignore_3",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -568,11 +748,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675337566,
-        "narHash": "sha256-jmLBTQcs1jFOn8h1Q5b5XwPfYgFOtcZ3+mU9KvfC6Js=",
+        "lastModified": 1681413034,
+        "narHash": "sha256-/t7OjNQcNkeWeSq/CFLYVBfm+IEnkjoSm9iKvArnUUI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5668d079583a5b594cb4e0cc0e6d84f1b93da7ae",
+        "rev": "d3de8f69ca88fb6f8b09e5b598be5ac98d28ede5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flox develop runix is failing since the version of floxpkgs in use doesn't set meta.position for the floxEnv