### PR TITLE
feat: improve handling of "abbreviated" flake refs

### DIFF
--- a/crates/runix/Cargo.toml
+++ b/crates/runix/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "2.2.0"
 serde_urlencoded = "0.7.1"
-url = { version = "2.3", features = ["serde"] }
+url = { version = "2.4", features = ["serde"] }
 percent-encoding = "2.2"
 shell-escape = "0.1.5"
 tokio = { version = "1.21", features = ["full"] }

--- a/crates/runix/Cargo.toml
+++ b/crates/runix/Cargo.toml
@@ -28,3 +28,7 @@ thiserror = "1.0"
 chrono = { version = "0.4.24", features = ["serde"] }
 regex = "1.7.2"
 once_cell = "1.17.1"
+
+[dev-dependencies]
+tempfile = "3"
+pathdiff = "0.2.1"

--- a/crates/runix/src/command_line/mod.rs
+++ b/crates/runix/src/command_line/mod.rs
@@ -73,7 +73,7 @@ impl CommandExt for std::process::Command {
         debug!(
             "Invoking {executable}:\nenv = {env:?}\nargs = {args:#?}",
             executable = shell_escape::escape(self.get_program().to_string_lossy()),
-            env = self.get_envs().into_iter().collect::<HashMap<_, _>>(),
+            env = self.get_envs().collect::<HashMap<_, _>>(),
             args = self
                 .get_args()
                 .map(|arg| arg.to_string_lossy().to_string())

--- a/crates/runix/src/flake_ref/file.rs
+++ b/crates/runix/src/flake_ref/file.rs
@@ -190,12 +190,6 @@ impl<Protocol: FileProtocol, App: ApplicationProtocol> FlakeRefSource
     ///    In some cases this application can be deduced from the url,
     ///    e.g. by looking at the path and file extension. (See [ApplicationProtocol::required])
     fn parses(maybe_ref: &Url) -> bool {
-        // let url = if let Ok(url) = Url::parse(maybe_ref) {
-        //     url
-        // } else {
-        //     return false;
-        // };
-
         if maybe_ref.scheme() == Self::scheme() {
             return true;
         }

--- a/crates/runix/src/flake_ref/file.rs
+++ b/crates/runix/src/flake_ref/file.rs
@@ -189,18 +189,18 @@ impl<Protocol: FileProtocol, App: ApplicationProtocol> FlakeRefSource
     ///    Nix supports tarballs as their own filetype.
     ///    In some cases this application can be deduced from the url,
     ///    e.g. by looking at the path and file extension. (See [ApplicationProtocol::required])
-    fn parses(maybe_ref: &str) -> bool {
-        let url = if let Ok(url) = Url::parse(maybe_ref) {
-            url
-        } else {
-            return false;
-        };
+    fn parses(maybe_ref: &Url) -> bool {
+        // let url = if let Ok(url) = Url::parse(maybe_ref) {
+        //     url
+        // } else {
+        //     return false;
+        // };
 
-        if url.scheme() == Self::scheme() {
+        if maybe_ref.scheme() == Self::scheme() {
             return true;
         }
 
-        if !App::required(&url) && url.scheme() == Protocol::scheme() {
+        if !App::required(maybe_ref) && maybe_ref.scheme() == Protocol::scheme() {
             return true;
         }
 

--- a/crates/runix/src/flake_ref/git.rs
+++ b/crates/runix/src/flake_ref/git.rs
@@ -196,7 +196,7 @@ mod tests {
         );
     }
 
-    /// assert that relative file urls are rosolved to git urls correctly
+    /// assert that relative file urls are resolved to git urls correctly
     #[test]
     fn relative_git_urls() {
         let url = GitRef::<protocol::File>::from_str("git+file:..").unwrap();

--- a/crates/runix/src/flake_ref/git.rs
+++ b/crates/runix/src/flake_ref/git.rs
@@ -57,11 +57,11 @@ impl<Protocol: GitProtocol> GitRef<Protocol> {
 }
 
 impl<Protocol: GitProtocol> FlakeRefSource for GitRef<Protocol> {
+    type ParseErr = ParseGitError;
+
     fn scheme() -> Cow<'static, str> {
         format!("git+{inner}", inner = Protocol::scheme()).into()
     }
-
-    type ParseErr = ParseGitError;
 
     fn from_url(url: Url) -> Result<Self, Self::ParseErr> {
         if url.scheme() != Self::scheme() {
@@ -78,7 +78,6 @@ impl<Protocol: GitProtocol> FlakeRefSource for GitRef<Protocol> {
 
         Ok(GitRef { url, attributes })
     }
-
 }
 
 impl<Protocol: GitProtocol> Display for GitRef<Protocol> {

--- a/crates/runix/src/flake_ref/git.rs
+++ b/crates/runix/src/flake_ref/git.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
-use std::fmt::Display;
-use std::path::PathBuf;
+use std::fmt::{Debug, Display};
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
@@ -44,7 +44,7 @@ pub struct GitAttributes {
     pub dir: Option<PathBuf>,
 }
 
-pub trait GitProtocol: Protocol {}
+pub trait GitProtocol: Protocol + Debug {}
 impl GitProtocol for protocol::File {}
 impl GitProtocol for protocol::SSH {}
 impl GitProtocol for protocol::HTTP {}
@@ -74,7 +74,26 @@ impl<Protocol: GitProtocol> FlakeRefSource for GitRef<Protocol> {
         let attributes: GitAttributes =
             serde_urlencoded::from_str(url.query().unwrap_or_default())?;
 
-        let url = GitUrl::<Protocol>::from_str(url.as_str().trim_start_matches("git+"))?;
+        // Special Urls (File, Http, Https, Ftp) are by spec required to be absolute
+        // since we are storing the internal Url in a spec compliant way,
+        // we need to canonicalize/resolve relative paths.
+        // This differs from the implementation found in nix which uses a non-spec-compliant
+        // url implementation which supports `file:relative/path` urls
+        // <https://github.com/NixOS/nix/blob/bf7dc3c7dc24f75fa623135750e8f10b8bcd94f9/src/libfetchers/git.cc#L261>
+        let url = {
+            let mut inner_url = Url::parse(url.as_str().trim_start_matches("git+"))?;
+
+            let mut path = Path::new(url.path()).to_path_buf();
+            if path.is_relative() {
+                path = path
+                    .canonicalize()
+                    .map_err(|e| ParseGitError::Canonicalize(path, e))?;
+            }
+
+            inner_url.set_path(&format!("{}", path.to_string_lossy()));
+
+            GitUrl::<Protocol>::try_from(inner_url)?
+        };
 
         Ok(GitRef { url, attributes })
     }
@@ -114,6 +133,8 @@ pub enum ParseGitError {
     NoRepo,
     #[error("Couldn't parse query: {0}")]
     Query(#[from] serde_urlencoded::de::Error),
+    #[error("Could not resolve relative path '{0:?}': {1}")]
+    Canonicalize(PathBuf, std::io::Error),
 }
 
 #[cfg(test)]
@@ -173,5 +194,54 @@ mod tests {
             serde_json::from_value::<GitRef<protocol::SSH>>(expected).unwrap(),
             flakeref
         );
+    }
+
+    /// assert that relative file urls are
+    #[test]
+    fn relative_git_urls() {
+        let url = GitRef::<protocol::File>::from_str("git+file:..").unwrap();
+        assert_eq!(
+            url.url.path(),
+            std::env::current_dir()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .to_string_lossy()
+        );
+        dbg!(url.to_string());
+
+        let url = GitRef::<protocol::File>::from_str("git+file:../").unwrap();
+        dbg!(&url);
+
+        assert_eq!(
+            url.url.path(),
+            std::env::current_dir()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .to_string_lossy()
+        );
+        dbg!(url.to_string());
+
+        // with "//" an absolute path is required prt the Url spec for file urls
+        let url = GitRef::<protocol::File>::from_str("git+file:///var/www").unwrap();
+        dbg!(&url);
+        assert_eq!(url.url.path(), "/var/www");
+        dbg!(url.to_string());
+
+        // with "//" an absolute path is required prt the Url spec for file urls
+        // relative paths such as var/www below are parsed as
+        //
+        //     var/www
+        //        ^^^^ path
+        //     ^^^ host
+        // This also affects `./some/folder` where `.` will be interpreted as a host
+        let url = GitRef::<protocol::File>::from_str("git+file://var/www").unwrap();
+        dbg!(&url);
+        assert_ne!(url.url.path(), "/var/www");
+        assert_eq!(url.url.host_str(), Some("var"));
+        assert_eq!(url.url.path(), "/www");
+
+        dbg!(url.to_string());
     }
 }

--- a/crates/runix/src/flake_ref/git.rs
+++ b/crates/runix/src/flake_ref/git.rs
@@ -196,7 +196,7 @@ mod tests {
         );
     }
 
-    /// assert that relative file urls are
+    /// assert that relative file urls are rosolved to git urls correctly
     #[test]
     fn relative_git_urls() {
         let url = GitRef::<protocol::File>::from_str("git+file:..").unwrap();
@@ -223,13 +223,13 @@ mod tests {
         );
         dbg!(url.to_string());
 
-        // with "//" an absolute path is required prt the Url spec for file urls
+        // with "//" an absolute path is required per the Url spec for file urls
         let url = GitRef::<protocol::File>::from_str("git+file:///var/www").unwrap();
         dbg!(&url);
         assert_eq!(url.url.path(), "/var/www");
         dbg!(url.to_string());
 
-        // with "//" an absolute path is required prt the Url spec for file urls
+        // with "//" an absolute path is required per the Url spec for file urls
         // relative paths such as var/www below are parsed as
         //
         //     var/www

--- a/crates/runix/src/flake_ref/git_service.rs
+++ b/crates/runix/src/flake_ref/git_service.rs
@@ -113,15 +113,13 @@ impl<Service: Default> GitServiceRef<Service> {
 }
 
 impl<Service: service::GitServiceHost> FlakeRefSource for GitServiceRef<Service> {
+    type ParseErr = ParseGitServiceError;
+
     fn scheme() -> Cow<'static, str> {
         Service::scheme()
     }
-}
-impl<Service: service::GitServiceHost> FromStr for GitServiceRef<Service> {
-    type Err = ParseGitServiceError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let url = Url::parse(s)?;
+    fn from_url(url: Url) -> Result<Self, Self::ParseErr> {
         if url.scheme() != Self::scheme() {
             return Err(ParseGitServiceError::InvalidScheme(
                 Self::scheme().to_string(),
@@ -160,6 +158,14 @@ impl<Service: service::GitServiceHost> FromStr for GitServiceRef<Service> {
             attributes,
             _type: Default::default(),
         })
+    }
+}
+impl<Service: service::GitServiceHost> FromStr for GitServiceRef<Service> {
+    type Err = ParseGitServiceError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let url = Url::parse(s)?;
+        Self::from_url(url)
     }
 }
 

--- a/crates/runix/src/flake_ref/indirect.rs
+++ b/crates/runix/src/flake_ref/indirect.rs
@@ -45,19 +45,6 @@ impl FlakeRefSource for IndirectRef {
         "flake".into()
     }
 
-    fn parses(maybe_ref: &str) -> bool {
-        if maybe_ref.starts_with("flake:") {
-            return true;
-        }
-
-        if maybe_ref.contains(':') {
-            return false;
-        }
-
-        ('a'..='z').any(|prefix| maybe_ref.starts_with(prefix))
-            || ('A'..='Z').any(|prefix| maybe_ref.starts_with(prefix))
-    }
-
     fn from_url(url: Url) -> Result<Self, Self::ParseErr> {
         let id = url.path().to_string();
         let attributes = serde_urlencoded::from_str(url.query().unwrap_or_default())?;
@@ -95,9 +82,6 @@ impl FromStr for IndirectRef {
                 url_bad_scheme.scheme().to_string(),
                 Self::scheme().into_owned(),
             ))?,
-            Err(_) if Self::parses(s) && !s.starts_with(&*Self::scheme()) => {
-                Url::parse(&format!("{scheme}:{s}", scheme = Self::scheme()))?
-            },
             e => e?,
         };
         Self::from_url(url)

--- a/crates/runix/src/flake_ref/indirect.rs
+++ b/crates/runix/src/flake_ref/indirect.rs
@@ -105,6 +105,7 @@ mod tests {
 
     use super::*;
     use crate::flake_ref::tests::roundtrip_to;
+    use crate::flake_ref::FlakeRef;
 
     /// Ensure that an indirect flake ref serializes without information loss
     #[test]
@@ -130,7 +131,10 @@ mod tests {
         };
 
         assert_eq!(IndirectRef::from_str("flake:nixpkgs").unwrap(), expected);
-        assert_eq!(IndirectRef::from_str("nixpkgs").unwrap(), expected);
+        assert_eq!(
+            FlakeRef::from_str("nixpkgs").unwrap(),
+            FlakeRef::Indirect(expected)
+        );
     }
 
     #[test]
@@ -140,7 +144,8 @@ mod tests {
 
     #[test]
     fn roundtrip_attributes() {
-        roundtrip_to::<IndirectRef>("nixpkgs?ref=master&dir=1", "flake:nixpkgs?dir=1&ref=master");
+        // IndirectRef does not convert non-well-defined flake urls on its own anymore
+        roundtrip_to::<FlakeRef>("nixpkgs?ref=master&dir=1", "flake:nixpkgs?dir=1&ref=master");
     }
 
     #[test]

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -525,7 +525,7 @@ pub(super) mod tests {
         let path = pathdiff::diff_paths(&basic, env::current_dir().unwrap()).unwrap();
 
         assert_eq!(
-            FlakeRef::resolve_local(&path.to_string_lossy())
+            FlakeRef::resolve_local(path.to_string_lossy())
                 .unwrap()
                 .to_string(),
             Url::parse(&format!("path:{}", basic.to_string_lossy()))
@@ -588,7 +588,7 @@ pub(super) mod tests {
         let git_dir_string = git_dir.to_string_lossy();
 
         assert_eq!(
-            FlakeRef::resolve_local(&flake_root.to_string_lossy())
+            FlakeRef::resolve_local(flake_root.to_string_lossy())
                 .unwrap()
                 .to_string(),
             Url::parse(&format!("git+file:{git_dir_string}?dir={flake_dir_name}"))

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -200,7 +200,7 @@ impl FlakeRef {
             }
 
             if ancestor.join("flake.nix").exists() {
-                debug!("found for flake in {ancestor:?}");
+                debug!("found flake in {ancestor:?}");
                 break ancestor;
             }
 
@@ -496,6 +496,8 @@ pub(super) mod tests {
         ));
     }
 
+    /// basic
+    /// └── flake.nix
     #[test]
     fn test_resolve_absolute_non_git_local() {
         let flake_test_dir = tempfile::tempdir().unwrap();
@@ -532,6 +534,9 @@ pub(super) mod tests {
         )
     }
 
+    /// withgit
+    /// ├── .git
+    /// └── flake.nix
     #[test]
     fn test_resolve_absolute_git_local() {
         let flake_test_dir = tempfile::tempdir().unwrap();
@@ -557,6 +562,10 @@ pub(super) mod tests {
         )
     }
 
+    /// withgit
+    /// ├── .git
+    /// └── inner
+    ///     └── flake.nix
     #[test]
     fn test_resolve_absolute_git_local_nested() {
         let flake_test_dir = tempfile::tempdir().unwrap();

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::fmt::Display;
-use std::path::{PathBuf, Component};
 use std::str::FromStr;
 
 use chrono::{NaiveDateTime, TimeZone, Utc};
@@ -11,13 +10,11 @@ use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 use url::Url;
 
-use self::file::application::ApplicationProtocol;
-use self::file::{FileRef, TarballRef, application};
+use self::file::{FileRef, TarballRef};
 use self::git::GitRef;
 use self::git_service::{service, GitServiceRef};
 use self::indirect::IndirectRef;
 use self::path::PathRef;
-use self::protocol::Protocol;
 
 pub mod file;
 pub mod git;
@@ -27,10 +24,10 @@ pub mod lock;
 pub mod path;
 pub mod protocol;
 
-pub static FLAKE_ID_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new("[a-zA-Z][a-zA-Z0-9_-]*").unwrap());
+pub static FLAKE_ID_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new("[a-zA-Z][a-zA-Z0-9_-]*").unwrap());
 
-
-pub trait FlakeRefSource:  FromStr + Display {
+pub trait FlakeRefSource: FromStr + Display {
     type ParseErr;
 
     fn scheme() -> Cow<'static, str>;
@@ -113,16 +110,9 @@ impl FromStr for FlakeRef {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let url = Url::parse(s).unwrap();
-
-
-
-
         let flake_ref = match url.scheme() {
-            protocol::File::scheme() if application::File::required(&url) =>  FileRef::<protocol::File>::from_url(url)?.into(),
-
-
             _ if FileRef::<protocol::File>::parses(s) => {
-                s.parse::<
+                s.parse::<FileRef<protocol::File>>()?.into()
             },
             _ if FileRef::<protocol::HTTP>::parses(s) => {
                 s.parse::<FileRef<protocol::HTTP>>()?.into()

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -200,7 +200,7 @@ impl FlakeRef {
                 break ancestor;
             }
 
-            if path.join(".git").exists() {
+            if ancestor.join(".git").exists() {
                 Err(ResolveLocalRefError::GitRepoBoundary(
                     ancestor.to_path_buf(),
                 ))?;

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -87,7 +87,7 @@ impl FromStr for FlakeRef {
                     FlakeRef::resolve_local(s)?
                 };
 
-                info!("Could not parse flakeref as URL, resolved locally to '{resolved:?}'");
+                info!("Could not parse flakeref as URL; resolved locally to '{resolved:?}'");
 
                 resolved
             },

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -682,7 +682,7 @@ pub(super) mod tests {
         // nix does not prescribe using the `dir` parameter as an alternative root to search for flakes.
         // So even though we parse
         //    /<git_root>/inner -> git+file://<git_root>?dir=inner
-        // It is not possible to reger to an inner path using a `dir` parameter in a non-well-defined url.
+        // It is not possible to refer to an inner path using a `dir` parameter in a non-well-defined url.
         assert!(matches!(
             dbg!(
                 FlakeRef::resolve_local(format!("{}?dir=inner", git_dir.to_string_lossy()))

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -665,7 +665,7 @@ pub(super) mod tests {
         ));
 
         // /<git_root>/inner?dir=inner
-        // nix does resolves the path to
+        // nix resolves the path to
         //    git+file://<git_root>?dir=inner
         // and does not accept an existing `dir` parameter in that case to avoid ambuguity
         assert!(matches!(

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -29,7 +29,7 @@ pub mod path;
 pub mod protocol;
 
 pub static FLAKE_ID_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new("[a-zA-Z][a-zA-Z0-9_-]*").unwrap());
+    Lazy::new(|| Regex::new("^[a-zA-Z][a-zA-Z0-9_-]*(/[a-zA-Z][a-zA-Z0-9_-])*\\??").unwrap());
 
 pub trait FlakeRefSource: FromStr + Display {
     type ParseErr;
@@ -38,8 +38,8 @@ pub trait FlakeRefSource: FromStr + Display {
 
     fn from_url(url: Url) -> Result<Self, Self::ParseErr>;
 
-    fn parses(maybe_ref: &str) -> bool {
-        maybe_ref.starts_with(&format!("{}:", Self::scheme()))
+    fn parses(maybe_ref: &Url) -> bool {
+        maybe_ref.scheme() == Self::scheme()
     }
 }
 
@@ -93,44 +93,50 @@ impl FromStr for FlakeRef {
             },
         };
 
+        dbg!(&url);
+
         let flake_ref = match url.scheme() {
-            _ if FileRef::<protocol::File>::parses(s) => {
-                s.parse::<FileRef<protocol::File>>()?.into()
+            _ if FileRef::<protocol::File>::parses(&url) => {
+                FileRef::<protocol::File>::from_url(url)?.into()
             },
-            _ if FileRef::<protocol::HTTP>::parses(s) => {
-                s.parse::<FileRef<protocol::HTTP>>()?.into()
+            _ if FileRef::<protocol::HTTP>::parses(&url) => {
+                FileRef::<protocol::HTTP>::from_url(url)?.into()
             },
-            _ if FileRef::<protocol::HTTPS>::parses(s) => {
-                s.parse::<FileRef<protocol::HTTPS>>()?.into()
+            _ if FileRef::<protocol::HTTPS>::parses(&url) => {
+                FileRef::<protocol::HTTPS>::from_url(url)?.into()
             },
-            _ if TarballRef::<protocol::File>::parses(s) => {
-                s.parse::<TarballRef<protocol::File>>()?.into()
+            _ if TarballRef::<protocol::File>::parses(&url) => {
+                TarballRef::<protocol::File>::from_url(url)?.into()
             },
-            _ if TarballRef::<protocol::HTTP>::parses(s) => {
-                s.parse::<TarballRef<protocol::HTTP>>()?.into()
+            _ if TarballRef::<protocol::HTTP>::parses(&url) => {
+                TarballRef::<protocol::HTTP>::from_url(url)?.into()
             },
-            _ if TarballRef::<protocol::HTTPS>::parses(s) => {
-                s.parse::<TarballRef<protocol::HTTPS>>()?.into()
+            _ if TarballRef::<protocol::HTTPS>::parses(&url) => {
+                TarballRef::<protocol::HTTPS>::from_url(url)?.into()
             },
-            _ if GitServiceRef::<service::Github>::parses(s) => {
-                s.parse::<GitServiceRef<service::Github>>()?.into()
+            _ if GitServiceRef::<service::Github>::parses(&url) => {
+                GitServiceRef::<service::Github>::from_url(url)?.into()
             },
-            _ if GitServiceRef::<service::Gitlab>::parses(s) => {
-                s.parse::<GitServiceRef<service::Gitlab>>()?.into()
+            _ if GitServiceRef::<service::Gitlab>::parses(&url) => {
+                GitServiceRef::<service::Gitlab>::from_url(url)?.into()
             },
-            _ if PathRef::parses(s) => s.parse::<PathRef>()?.into(),
-            _ if GitRef::<protocol::File>::parses(s) => {
+            _ if PathRef::parses(&url) => PathRef::from_url(url)?.into(),
+            _ if GitRef::<protocol::File>::parses(&url) => {
                 dbg!(GitRef::<protocol::File>::from_url(dbg!(url))?.into())
             },
-            _ if GitRef::<protocol::SSH>::parses(s) => s.parse::<GitRef<protocol::SSH>>()?.into(),
-            _ if GitRef::<protocol::HTTP>::parses(s) => s.parse::<GitRef<protocol::HTTP>>()?.into(),
-            _ if GitRef::<protocol::HTTPS>::parses(s) => {
-                s.parse::<GitRef<protocol::HTTPS>>()?.into()
+            _ if GitRef::<protocol::SSH>::parses(&url) => {
+                GitRef::<protocol::SSH>::from_url(url)?.into()
             },
-            _ if IndirectRef::parses(s) => s.parse::<IndirectRef>()?.into(),
+            _ if GitRef::<protocol::HTTP>::parses(&url) => {
+                GitRef::<protocol::HTTP>::from_url(url)?.into()
+            },
+            _ if GitRef::<protocol::HTTPS>::parses(&url) => {
+                GitRef::<protocol::HTTPS>::from_url(url)?.into()
+            },
+            _ if IndirectRef::parses(&url) => IndirectRef::from_url(url)?.into(),
             _ => Err(ParseFlakeRefError::Invalid)?,
         };
-        Ok(flake_ref)
+        dbg!(Ok(flake_ref))
     }
 }
 

--- a/crates/runix/src/flake_ref/path.rs
+++ b/crates/runix/src/flake_ref/path.rs
@@ -48,12 +48,6 @@ impl FlakeRefSource for PathRef {
         "path".into()
     }
 
-    fn parses(maybe_ref: &str) -> bool {
-        ["path:", "/", "."]
-            .iter()
-            .any(|prefix| maybe_ref.starts_with(prefix))
-    }
-
     fn from_url(url: Url) -> Result<Self, Self::ParseErr> {
         if url.scheme() != Self::scheme() {
             return Err(ParsePathRefError::InvalidScheme(
@@ -73,13 +67,7 @@ impl FromStr for PathRef {
     type Err = ParsePathRefError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let url = match Url::parse(s) {
-            Ok(url) => url,
-            Err(_) if Self::parses(s) && !s.starts_with(&*Self::scheme()) => {
-                Url::parse(&format!("path:{s}"))?
-            },
-            e => e?,
-        };
+        let url = Url::parse(s)?;
         Self::from_url(url)
     }
 }

--- a/crates/runix/src/flake_ref/path.rs
+++ b/crates/runix/src/flake_ref/path.rs
@@ -107,16 +107,13 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use super::*;
+    use crate::flake_ref::FlakeRef;
 
     #[test]
     fn parses_path_flakeref() {
         assert_eq!(
-            PathRef::from_str("/some/where").unwrap(),
-            PathRef::from_str("path:///some/where").unwrap()
-        );
-        assert_eq!(
-            PathRef::from_str("./some/where").unwrap(),
-            PathRef::from_str("path:./some/where").unwrap()
+            FlakeRef::from_str("path:/can/be/missing").unwrap(),
+            FlakeRef::Path(PathRef::from_str("path:/can/be/missing").unwrap())
         );
     }
 


### PR DESCRIPTION
If not well defined, i.e. if the flakeref cannot be parsed as a url,
we resolve it either as an indirect flake or local path.

Note: if not "well-defined" parsing flakerefs is "impure",
      i.e. depends on the state of the local system (files).
      The resulting flakeref however, serializes into well-defined form.


Resolving an abbreviated URL to local files:

Nix supports referring to local files/paths without an explicit scheme.
However, it distinguishes between flakes in git repositories
(disambiguated using `git+file://`) from "free" ones (`path:`).
The logic for this in nix can be found at <https://github.com/NixOS/nix/blob/bf7dc3c7dc24f75fa623135750e8f10b8bcd94f9/src/libexpr/flake/flakeref.cc#L112C5-L197>
This method implements a subset of this logic assuming we require the path to exist and to be a flake.
In abstract we
1. locate a flake (by finding a `flake.nix` in all ancestors)
  - fail if directory does not exist
  - fail if skipping file system boundaries
  - fail if "exiting" a git repository (if there is one)
2. locate the root of the "containing" git repo (if applicable)
  - check whether `.git/shallow` exists and track in the url params
  - ensure there is no `?dir=` param if flake is in a subdir
3. construct a `file+git:` or `path:` url as required


Additionally this PR refactors the parsing of flakerefs in https://github.com/flox/runix/commit/5c91d2a4f3b2752d6ecac6127311cad2a3d3f4c8 to be URL first.

So far, all flakeref parsers implemented the parsing as `FromStr` only.
In all cases `FromStr` would first parse the input as `Url` and then process mainly the Url.
After this refactoring all flakerefs can only be _purely_ parsed using Urls or "well-defined" url strings (see above).
`FromStr` is now uniformly implemented as

    fn from_str(s: &str) -> Result<Self, Self::Err> {
        let url = Url::parse(s)?;
        Self::from_url(url)
    }

for all `FlakeRef` types.

If "impure" resolution is necessary, `FlakeRef::resolve_local` provides an interface to create a well-defined Url.
`FlakeRef::from_str` by always tries to impurely resolve urls for inputs that are not well-defined.

The change makes `FlakeRef` instances pure by default, which simplifies the parsing as impure components are stripped out.