### PR TITLE
fix: flakeMetadata and locked flakeRef types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
       run: flox activate -e .#runix -- cargo clippy
 
     - name: check format
-      run: flox activate -e .#runix -- cargo fmt --check
+      run: |
+        # flox activate does not activate with the current flake's self context :X
+        flox build .#rustfmt
+        ./result/bin/cargo-fmt --check
 
     - name: run tests
       run: flox activate -e .#runix -- cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
       run: |
         # flox activate does not activate with the current flake's self context :X
         flox build .#rustfmt
-        ./result/bin/cargo-fmt --check
+        export PATH="./result/bin:$PATH"
+        flox activate -e .#runix -- cargo fmt --check
 
     - name: run tests
       run: flox activate -e .#runix -- cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
         github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
 
     - name: check clippy
-      run: flox develop runix -c cargo clippy
+      run: flox activate -e .#runix -- cargo clippy
 
     - name: check format
-      run: flox develop runix -c cargo fmt --check
+      run: flox activate -e .#runix -- cargo fmt --check
 
     - name: run tests
-      run: flox develop runix -c cargo test
+      run: flox activate -e .#runix -- cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+
+  check:
+    name: Check runix
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Install flox
+      uses: flox/install-flox-action@main
+      with:
+        github-access-token: ${{ secrets.NIX_GIT_TOKEN }}
+
+    - name: check clippy
+      run: flox develop runix -c cargo clippy
+
+    - name: check format
+      run: flox develop runix -c cargo fmt --check
+
+    - name: run tests
+      run: flox develop runix -c cargo test

--- a/crates/runix/src/flake_metadata.rs
+++ b/crates/runix/src/flake_metadata.rs
@@ -13,7 +13,7 @@ pub type FlakeLock = serde_json::Value;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FlakeMetadata {
-    pub description: String,
+    pub description: Option<String>,
     pub last_modified: flake_ref::Timestamp,
 
     pub locks: FlakeLock,

--- a/crates/runix/src/flake_ref/git.rs
+++ b/crates/runix/src/flake_ref/git.rs
@@ -147,6 +147,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::flake_ref::FlakeRef;
 
     static FLAKE_REF: &'_ str = "git+file:///somewhere/on/the/drive?shallow=false&submodules=false&ref=feature%2Fxyz&dir=abc&lastModified=1666570118";
 
@@ -202,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    fn to_from_json1() {
+    fn from_json() {
         let expected = json!({
           "lastModified": 1688730350,
           "narHash": "sha256-Gzcv5BkK4SIQVbxqMLxIBbJJcC0k6nGjgfve0X5lSzw=",
@@ -212,8 +213,8 @@ mod tests {
           "type": "git",
           "url": "ssh://git@github.com/flox/flox"
         });
-
-        serde_json::from_value::<GitRef<protocol::SSH>>(expected).expect("should parse");
+        serde_json::from_value::<GitRef<protocol::SSH>>(expected.clone()).expect("should parse");
+        serde_json::from_value::<FlakeRef>(expected).expect("should parse");
     }
 
     /// assert that relative file urls are resolved to git urls correctly

--- a/crates/runix/src/flake_ref/git.rs
+++ b/crates/runix/src/flake_ref/git.rs
@@ -8,7 +8,7 @@ use serde_with::skip_serializing_none;
 use thiserror::Error;
 use url::Url;
 
-use super::lock::{Rev, RevCount};
+use super::lock::{LastModified, Rev, RevCount};
 use super::protocol::{self, Protocol, WrappedUrl, WrappedUrlParseError};
 use super::FlakeRefSource;
 
@@ -42,6 +42,9 @@ pub struct GitAttributes {
     pub reference: Option<String>,
 
     pub dir: Option<PathBuf>,
+
+    #[serde(flatten)]
+    pub last_modified: Option<LastModified>,
 }
 
 pub trait GitProtocol: Protocol + Debug {}
@@ -140,6 +143,7 @@ pub enum ParseGitError {
 #[cfg(test)]
 mod tests {
 
+    use chrono::{TimeZone, Utc};
     use serde_json::json;
 
     use super::*;
@@ -157,6 +161,7 @@ mod tests {
                 rev_count: None,
                 dir: Some("abc".into()),
                 rev: None,
+                last_modified: Some(Utc.timestamp_opt(1666570118, 0).unwrap().into()),
                 reference: Some("feature/xyz".to_string()),
             },
         };

--- a/crates/runix/src/flake_ref/git.rs
+++ b/crates/runix/src/flake_ref/git.rs
@@ -43,7 +43,7 @@ pub struct GitAttributes {
 
     pub dir: Option<PathBuf>,
 
-    #[serde(flatten)]
+    #[serde(rename = "lastModified")]
     pub last_modified: Option<LastModified>,
 }
 
@@ -148,7 +148,7 @@ mod tests {
 
     use super::*;
 
-    static FLAKE_REF: &'_ str = "git+file:///somewhere/on/the/drive?shallow=false&submodules=false&ref=feature%2Fxyz&dir=abc";
+    static FLAKE_REF: &'_ str = "git+file:///somewhere/on/the/drive?shallow=false&submodules=false&ref=feature%2Fxyz&dir=abc&lastModified=1666570118";
 
     #[test]
     fn parses_git_path_flakeref() {
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn parses_unsescaped_qs() {
         assert_eq!(
-            "git+file:///somewhere/on/the/drive?shallow=false&submodules=false&ref=feature/xyz&dir=abc"
+            "git+file:///somewhere/on/the/drive?shallow=false&submodules=false&ref=feature/xyz&dir=abc&lastModified=1666570118"
                 .parse::<GitRef<protocol::File>>()
                 .unwrap()
                 .to_string(),
@@ -199,6 +199,21 @@ mod tests {
             serde_json::from_value::<GitRef<protocol::SSH>>(expected).unwrap(),
             flakeref
         );
+    }
+
+    #[test]
+    fn to_from_json1() {
+        let expected = json!({
+          "lastModified": 1688730350,
+          "narHash": "sha256-Gzcv5BkK4SIQVbxqMLxIBbJJcC0k6nGjgfve0X5lSzw=",
+          "ref": "refs/heads/main",
+          "rev": "0630fc9307852b30ea4c5915b6b74fa9db51d641",
+          "revCount": 542,
+          "type": "git",
+          "url": "ssh://git@github.com/flox/flox"
+        });
+
+        serde_json::from_value::<GitRef<protocol::SSH>>(expected).expect("should parse");
     }
 
     /// assert that relative file urls are resolved to git urls correctly

--- a/crates/runix/src/flake_ref/git.rs
+++ b/crates/runix/src/flake_ref/git.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -10,7 +11,7 @@ use url::Url;
 
 use super::lock::{LastModified, Rev, RevCount};
 use super::protocol::{self, Protocol, WrappedUrl, WrappedUrlParseError};
-use super::FlakeRefSource;
+use super::{FlakeRefSource, Timestamp, TimestampDeserialize};
 
 pub type GitUrl<Protocol> = WrappedUrl<Protocol>;
 
@@ -74,8 +75,34 @@ impl<Protocol: GitProtocol> FlakeRefSource for GitRef<Protocol> {
             ));
         }
 
-        let attributes: GitAttributes =
-            serde_urlencoded::from_str(url.query().unwrap_or_default())?;
+        let mut pairs = url
+            .query_pairs()
+            .map(|(k, v)| (k, v.to_string()))
+            .collect::<HashMap<_, _>>();
+
+        let attributes = GitAttributes {
+            shallow: pairs.remove("shallow").map(|v| v == "1"),
+            submodules: pairs.remove("submodules").map(|v| v == "1"),
+            all_refs: pairs.remove("allRefs").map(|v| v == "1"),
+            rev_count: pairs
+                .remove("revCount")
+                .map(|v| v.parse::<u64>())
+                .map_or(Ok(None), |v| v.map(Some))
+                .map_err(|e| ParseGitError::Query(e.to_string()))?
+                .map(RevCount),
+            rev: pairs
+                .remove("rev")
+                .map(|v| Rev::from_str(&v))
+                .map_or(Ok(None), |v| v.map(Some))
+                .map_err(|e| ParseGitError::Query(e.to_string()))?,
+            reference: pairs.remove("ref"),
+            dir: pairs.remove("dir").map(PathBuf::from),
+            last_modified: pairs
+                .remove("lastModified")
+                .map(|v| Timestamp::try_from(TimestampDeserialize::TsString(v)))
+                .map_or(Ok(None), |v| v.map(Some))
+                .map_err(|e| ParseGitError::Query(e.to_string()))?,
+        };
 
         // Special Urls (File, Http, Https, Ftp) are by spec required to be absolute
         // since we are storing the internal Url in a spec compliant way,
@@ -105,11 +132,35 @@ impl<Protocol: GitProtocol> FlakeRefSource for GitRef<Protocol> {
 impl<Protocol: GitProtocol> Display for GitRef<Protocol> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut url = Url::parse(&format!("git+{url}", url = self.url)).unwrap();
-        url.set_query(
-            serde_urlencoded::to_string(&self.attributes)
-                .ok()
-                .as_deref(),
-        );
+
+        let mut pairs = url.query_pairs_mut();
+
+        if let Some(v) = self.attributes.all_refs {
+            pairs.append_pair("allRefs", &(v as u8).to_string());
+        }
+        if let Some(ref v) = self.attributes.dir {
+            pairs.append_pair("dir", &v.to_string_lossy());
+        }
+        if let Some(ref v) = self.attributes.last_modified {
+            pairs.append_pair("lastModified", &v.0.timestamp().to_string());
+        }
+        if let Some(ref v) = self.attributes.reference {
+            pairs.append_pair("ref", v);
+        }
+        if let Some(ref v) = self.attributes.rev {
+            pairs.append_pair("rev", v);
+        }
+        if let Some(ref v) = self.attributes.rev_count {
+            pairs.append_pair("revCount", &v.0.to_string());
+        }
+        if let Some(v) = self.attributes.shallow {
+            pairs.append_pair("shallow", &(v as u8).to_string());
+        }
+        if let Some(v) = self.attributes.submodules {
+            pairs.append_pair("submodules", &(v as u8).to_string());
+        }
+
+        let url = pairs.finish();
 
         write!(f, "{url}")
     }
@@ -135,7 +186,7 @@ pub enum ParseGitError {
     #[error("No repo specified")]
     NoRepo,
     #[error("Couldn't parse query: {0}")]
-    Query(#[from] serde_urlencoded::de::Error),
+    Query(String),
     #[error("Could not resolve relative path '{0:?}': {1}")]
     Canonicalize(PathBuf, std::io::Error),
 }
@@ -149,7 +200,7 @@ mod tests {
     use super::*;
     use crate::flake_ref::FlakeRef;
 
-    static FLAKE_REF: &'_ str = "git+file:///somewhere/on/the/drive?shallow=false&submodules=false&ref=feature%2Fxyz&dir=abc&lastModified=1666570118";
+    static FLAKE_REF: &'_ str = "git+file:///somewhere/on/the/drive?dir=abc&lastModified=1666570118&ref=feature%2Fxyz&shallow=0&submodules=0";
 
     #[test]
     fn parses_git_path_flakeref() {
@@ -174,11 +225,30 @@ mod tests {
     #[test]
     fn parses_unsescaped_qs() {
         assert_eq!(
-            "git+file:///somewhere/on/the/drive?shallow=false&submodules=false&ref=feature/xyz&dir=abc&lastModified=1666570118"
+            "git+file:///somewhere/on/the/drive?shallow=0&submodules=0&ref=feature/xyz&dir=abc&lastModified=1666570118"
                 .parse::<GitRef<protocol::File>>()
                 .unwrap()
                 .to_string(),
             FLAKE_REF)
+    }
+
+    #[test]
+    fn parses_bools() {
+        let expected: GitRef<protocol::File> = GitRef {
+            url: "file:///somewhere/on/the/drive".parse().unwrap(),
+            attributes: GitAttributes {
+                shallow: Some(false),
+                submodules: Some(true),
+                all_refs: Some(false), // sic only "1" is parsed as true
+                ..Default::default()
+            },
+        };
+        assert_eq!(
+            "git+file:///somewhere/on/the/drive?shallow=0&submodules=1&allRefs=true"
+                .parse::<GitRef<protocol::File>>()
+                .unwrap(),
+            expected
+        )
     }
 
     #[test]
@@ -211,7 +281,9 @@ mod tests {
           "rev": "0630fc9307852b30ea4c5915b6b74fa9db51d641",
           "revCount": 542,
           "type": "git",
-          "url": "ssh://git@github.com/flox/flox"
+          "url": "ssh://git@github.com/flox/flox",
+          "shallow": true,
+          "submodules": false,
         });
         serde_json::from_value::<GitRef<protocol::SSH>>(expected.clone()).expect("should parse");
         serde_json::from_value::<FlakeRef>(expected).expect("should parse");

--- a/crates/runix/src/flake_ref/git.rs
+++ b/crates/runix/src/flake_ref/git.rs
@@ -162,6 +162,10 @@ impl<Protocol: GitProtocol> Display for GitRef<Protocol> {
 
         let url = pairs.finish();
 
+        if matches!(url.query(), Some("")) {
+            url.set_query(None)
+        }
+
         write!(f, "{url}")
     }
 }

--- a/crates/runix/src/flake_ref/git_service.rs
+++ b/crates/runix/src/flake_ref/git_service.rs
@@ -38,10 +38,10 @@ pub struct GitServiceAttributes {
 
     pub rev: Option<Rev>,
 
-    #[serde(flatten)]
+    #[serde(rename = "narHash")]
     pub nar_hash: Option<NarHash>,
 
-    #[serde(flatten)]
+    #[serde(rename = "lastModified")]
     pub last_modified: Option<LastModified>,
 }
 

--- a/crates/runix/src/flake_ref/lock.rs
+++ b/crates/runix/src/flake_ref/lock.rs
@@ -55,7 +55,7 @@ pub struct InvalidRev;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(try_from = "StringOrInt")]
-pub struct RevCount(u64);
+pub struct RevCount(pub u64);
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]

--- a/crates/runix/src/flake_ref/lock.rs
+++ b/crates/runix/src/flake_ref/lock.rs
@@ -58,6 +58,7 @@ pub struct InvalidRev;
 pub struct RevCount(u64);
 
 #[derive(Debug, Deserialize)]
+#[serde(untagged)]
 enum StringOrInt {
     String(String),
     Int(u64),

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -367,8 +367,6 @@ pub(super) mod tests {
     use std::fmt::Debug;
     use std::fs::{self, File};
 
-    use serde_json::json;
-
     use super::*;
 
     #[test]

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -10,7 +10,7 @@ use derive_more::{Display, From};
 use log::{debug, info};
 use once_cell::sync::Lazy;
 use regex::Regex;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
@@ -303,7 +303,8 @@ pub enum ParseFlakeRefError {
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, From, Clone)]
 #[serde(try_from = "TimestampDeserialize")]
 pub struct Timestamp(
-    #[serde(serialize_with = "chrono::serde::ts_seconds::serialize")] chrono::DateTime<chrono::Utc>,
+    #[serde(serialize_with = "chrono::serde::ts_seconds::serialize")]
+    pub  chrono::DateTime<chrono::Utc>,
 );
 
 #[derive(Deserialize, Debug)]
@@ -340,35 +341,6 @@ pub enum ParseTimeError {
     FromString(#[from] chrono::ParseError),
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-pub enum BoolReprs {
-    String(String),
-    Bool(bool),
-}
-
-impl TryFrom<BoolReprs> for bool {
-    type Error = <bool as FromStr>::Err;
-
-    fn try_from(value: BoolReprs) -> Result<Self, Self::Error> {
-        match value {
-            BoolReprs::String(s) => s.parse::<bool>(),
-            BoolReprs::Bool(b) => Ok(b),
-        }
-    }
-}
-
-impl BoolReprs {
-    pub fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        BoolReprs::deserialize(deserializer)?
-            .try_into()
-            .map_err(serde::de::Error::custom)
-    }
-}
-
 #[cfg(test)]
 pub(super) mod tests {
 
@@ -394,6 +366,8 @@ pub(super) mod tests {
     use std::env;
     use std::fmt::Debug;
     use std::fs::{self, File};
+
+    use serde_json::json;
 
     use super::*;
 

--- a/crates/runix/src/flake_ref/path.rs
+++ b/crates/runix/src/flake_ref/path.rs
@@ -88,6 +88,10 @@ impl Display for PathRef {
                 .as_deref(),
         );
 
+        if matches!(url.query(), Some("")) {
+            url.set_query(None)
+        }
+
         write!(f, "{url}")
     }
 }

--- a/crates/runix/src/store_path.rs
+++ b/crates/runix/src/store_path.rs
@@ -33,7 +33,7 @@ impl StorePath {
     ///
     /// let path = StorePath::from_path("/nix/store/7rjqb838snvvxcmpvck1smfxhkwzqal5-python3-3.10.10")
     ///     .unwrap();
-    /// assert_eq!(path.prefix(), Path::new(STORE_PREFIX.as_str()));
+    /// assert_eq!(path.prefix(), STORE_PREFIX.as_path())
     /// ```
     pub fn prefix(&self) -> &Path {
         &self.prefix
@@ -48,7 +48,7 @@ impl StorePath {
     /// let path = StorePath::from_path("/nix/store/7rjqb838snvvxcmpvck1smfxhkwzqal5-python3-3.10.10")
     ///     .unwrap();
     /// assert_eq!(
-    ///     path.name(),
+    ///     path.basename(),
     ///     "7rjqb838snvvxcmpvck1smfxhkwzqal5-python3-3.10.10"
     /// );
     /// ```


### PR DESCRIPTION
* add some missing fields in the attributes of git flake refs
* fix the rendering of attributes to query params (for flakerefs that contain bools)
* add a ci action to continuously test