### PR TITLE
feat: resolve indirect references

### DIFF
--- a/crates/runix/Cargo.toml
+++ b/crates/runix/Cargo.toml
@@ -31,4 +31,5 @@ once_cell = "1.17.1"
 
 [dev-dependencies]
 tempfile = "3"
+temp-env = "0.3.4"
 pathdiff = "0.2.1"

--- a/crates/runix/src/command_line/mod.rs
+++ b/crates/runix/src/command_line/mod.rs
@@ -234,7 +234,7 @@ impl NixCommandLine {
 
     // Set the global Nix config via the environment variables in flox.default_args so that
     // subprocesses called by `flox` (e.g. `parser-util`) can inherit them.
-    pub fn export_config_env_vars(&self) {
+    pub fn export_env_vars(&self) {
         for (name, value) in self.defaults.environment.iter() {
             std::env::set_var(name, value);
         }

--- a/crates/runix/src/command_line/mod.rs
+++ b/crates/runix/src/command_line/mod.rs
@@ -231,6 +231,14 @@ impl NixCommandLine {
 
         M::run(&mut command).await
     }
+
+    // Set the global Nix config via the environment variables in flox.default_args so that
+    // subprocesses called by `flox` (e.g. `parser-util`) can inherit them.
+    pub fn export_config_env_vars(&self) {
+        for (name, value) in self.defaults.environment.iter() {
+            std::env::set_var(name, value);
+        }
+    }
 }
 
 /// Create a list of arguments from `&Self`

--- a/crates/runix/src/flake_ref/indirect.rs
+++ b/crates/runix/src/flake_ref/indirect.rs
@@ -73,6 +73,10 @@ impl IndirectRef {
     }
 
     /// Resolves an indirect flake reference to a concrete reference
+    ///
+    /// Note that this method calls `parser-util`, which relies on the `NIX_USER_CONF_FILES`
+    /// environment variable to be set and contain conf files that point to custom registries
+    /// that you want to use for resolution, otherwise only the user's local registry is used.
     pub fn resolve(&self) -> Result<FlakeRef, UrlParseError> {
         let json = serde_json::to_string(&self.attributes)?;
         let resolved = resolve_flake_ref(json, PARSER_UTIL_BIN_PATH)?;

--- a/crates/runix/src/flake_ref/indirect.rs
+++ b/crates/runix/src/flake_ref/indirect.rs
@@ -78,7 +78,7 @@ impl IndirectRef {
     /// environment variable to be set and contain conf files that point to custom registries
     /// that you want to use for resolution, otherwise only the user's local registry is used.
     pub fn resolve(&self) -> Result<FlakeRef, UrlParseError> {
-        let json = serde_json::to_string(&self.attributes)?;
+        let json = serde_json::to_string(&self)?;
         let resolved = resolve_flake_ref(json, PARSER_UTIL_BIN_PATH)?;
         FlakeRef::from_parsed(&resolved.resolved_ref)
     }
@@ -148,9 +148,11 @@ pub enum ParseIndirectError {
 mod tests {
 
     use serde_json::json;
+    use temp_env::with_var;
 
     use super::*;
     use crate::flake_ref::FlakeRef;
+    use crate::registry::Registry;
     use crate::url_parser::PARSER_UTIL_BIN_PATH;
 
     /// Ensure that an indirect flake ref serializes without information loss
@@ -196,6 +198,45 @@ mod tests {
         let actual = IndirectRef::from_str("flake:nixpkgs").unwrap();
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn resolves_indirect_ref() {
+        let expected: FlakeRef = "github:flox/runix".parse().unwrap();
+
+        // create a new registry entry,
+        // because the original global/user flake registry is managed outside of the process
+        // so we can not depend on it
+        let mut registry = Registry::default();
+        registry.set("testref", expected.clone());
+
+        // write registry to a file
+        let tempdir = tempfile::tempdir().unwrap();
+        let registry_path = tempdir.path().join("registry.json");
+        std::fs::write(
+            &registry_path,
+            serde_json::to_string_pretty(&registry).unwrap(),
+        )
+        .unwrap();
+
+        // set `flake-registry` config value to our manaaged config
+        // and resolve the `test` entry
+        // and expect to get the same entry we set to the registry above
+        with_var(
+            "NIX_CONFIG",
+            Some(format!(
+                "flake-registry = {}",
+                registry_path.to_string_lossy()
+            )),
+            || {
+                let actual = IndirectRef::from_str("flake:testref")
+                    .unwrap()
+                    .resolve()
+                    .unwrap();
+
+                assert_eq!(actual, expected);
+            },
+        )
     }
 
     #[test]

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -214,12 +214,12 @@ impl FlakeRef {
     }
 
     /// Parses a URI into a flake reference given the URI and the path to the `parser-util` binary
-    pub fn from_url<U, P>(uri: U, bin_path: P) -> Result<Self, UrlParseError>
+    pub fn from_url<U, P>(url: U, bin_path: P) -> Result<Self, UrlParseError>
     where
-        U: AsRef<str> + Clone,
+        U: AsRef<str>,
         P: AsRef<Path>,
     {
-        let parsed = url_parser::installable_flake_ref(uri, bin_path)?;
+        let parsed = url_parser::installable_flake_ref(url, bin_path)?;
         let parsed_ref = parsed.r#ref;
         Self::from_parsed(&parsed_ref)
     }

--- a/crates/runix/src/flake_ref/mod.rs
+++ b/crates/runix/src/flake_ref/mod.rs
@@ -219,9 +219,9 @@ impl FlakeRef {
         U: AsRef<str> + Clone,
         P: AsRef<Path>,
     {
-        let parsed = url_parser::installable_flake_ref(uri.clone(), bin_path)?;
+        let parsed = url_parser::installable_flake_ref(uri, bin_path)?;
         let parsed_ref = parsed.r#ref;
-        Self::from_parsed(uri, &parsed_ref)
+        Self::from_parsed(&parsed_ref)
     }
 
     /// Converts a parsed flake reference from `parser-util` to a [FlakeRef]
@@ -229,10 +229,7 @@ impl FlakeRef {
     /// This method is agnostic over the resolution level of the parsed flake reference
     /// e.g. the original flake reference, the resolved flake reference, or the locked
     /// flake reference.
-    pub fn from_parsed<U>(uri: U, parsed_ref: &ParsedFlakeReference) -> Result<Self, UrlParseError>
-    where
-        U: AsRef<str> + Clone,
-    {
+    pub fn from_parsed(parsed_ref: &ParsedFlakeReference) -> Result<Self, UrlParseError> {
         match parsed_ref.flake_type {
             FlakeType::Path => {
                 let path_ref = PathRef::try_from(parsed_ref.attrs.clone())?;
@@ -390,14 +387,7 @@ impl FlakeRef {
             // improvements.
             FlakeType::Sourcehut => Err(UrlParseError::UnsupportedService("sourcehut".to_string())),
             FlakeType::Indirect => {
-                let mut attrs = parsed_ref.attrs.clone();
-                // Store the original URL so it can be extracted later
-                // and stored on the IndirectRef
-                attrs.insert(
-                    String::from("unparsed"),
-                    Value::String(String::from(uri.as_ref())),
-                );
-                let indirect_ref = IndirectRef::try_from(attrs)?;
+                let indirect_ref = IndirectRef::try_from(parsed_ref.attrs.clone())?;
                 Ok(FlakeRef::Indirect(indirect_ref))
             },
         }

--- a/crates/runix/src/registry.rs
+++ b/crates/runix/src/registry.rs
@@ -27,7 +27,7 @@ pub struct Registry {
 impl Registry {
     pub fn set(&mut self, name: impl ToString, to: FlakeRef) {
         let entry = RegistryEntry {
-            from: IndirectRef::new(name.to_string(), Default::default()),
+            from: IndirectRef::new(name.to_string(), name.to_string(), Default::default()),
             to,
             exact: None,
         };

--- a/crates/runix/src/registry.rs
+++ b/crates/runix/src/registry.rs
@@ -27,7 +27,7 @@ pub struct Registry {
 impl Registry {
     pub fn set(&mut self, name: impl ToString, to: FlakeRef) {
         let entry = RegistryEntry {
-            from: IndirectRef::new(name.to_string(), name.to_string(), Default::default()),
+            from: IndirectRef::new(name.to_string(), Default::default()),
             to,
             exact: None,
         };

--- a/crates/runix/src/url_parser.rs
+++ b/crates/runix/src/url_parser.rs
@@ -48,6 +48,8 @@ pub enum UrlParseError {
     Deserialize(#[from] serde_json::Error),
     #[error("parsed URL was missing attribute '{0}'")]
     MissingAttribute(&'static str),
+    #[error("failed to resolve URL")]
+    ResolutionFailed,
     // Everything after this point is self-inflicted trying to strongly type what Nix gave us
     #[error("bad timestamp")]
     BadTimestamp(#[from] ParseTimeError),
@@ -83,7 +85,7 @@ impl TryFrom<GenericParsedURL> for ResolvedFlakeRef {
             .ok_or_else(|| UrlParseError::MissingAttribute("input"))?;
         let original_ref = parsed
             .original_ref
-            .ok_or_else(|| UrlParseError::MissingAttribute("originalRef"))
+            .ok_or_else(|| UrlParseError::ResolutionFailed)
             .and_then(ParsedFlakeReference::try_from)?;
         let resolved_ref = parsed
             .resolved_ref
@@ -115,7 +117,7 @@ impl TryFrom<GenericParsedURL> for LockedFlakeRef {
         let locked_ref = parsed
             .locked_ref
             .take()
-            .ok_or_else(|| UrlParseError::MissingAttribute("lockedRef"))
+            .ok_or_else(|| UrlParseError::ResolutionFailed)
             .and_then(ParsedFlakeReference::try_from)?;
 
         let ResolvedFlakeRef {


### PR DESCRIPTION
This PR allows the `IndirectRef` type to resolve itself to a real flake location. It does this by storing the original flake reference on the `IndirectRef` type rather than trying to reconstruct it from the attributes stored in the `IndirectRef` to avoid any differences between the reconstructed and original URL.