### PR TITLE
fix: add test for resolving indirect references using parser-util

### DIFF
--- a/crates/runix/Cargo.toml
+++ b/crates/runix/Cargo.toml
@@ -31,4 +31,5 @@ once_cell = "1.17.1"
 
 [dev-dependencies]
 tempfile = "3"
+temp-env = "0.3.4"
 pathdiff = "0.2.1"

--- a/crates/runix/src/flake_ref/indirect.rs
+++ b/crates/runix/src/flake_ref/indirect.rs
@@ -78,7 +78,7 @@ impl IndirectRef {
     /// environment variable to be set and contain conf files that point to custom registries
     /// that you want to use for resolution, otherwise only the user's local registry is used.
     pub fn resolve(&self) -> Result<FlakeRef, UrlParseError> {
-        let json = serde_json::to_string(&self.attributes)?;
+        let json = serde_json::to_string(&self)?;
         let resolved = resolve_flake_ref(json, PARSER_UTIL_BIN_PATH)?;
         FlakeRef::from_parsed(&resolved.resolved_ref)
     }
@@ -148,9 +148,11 @@ pub enum ParseIndirectError {
 mod tests {
 
     use serde_json::json;
+    use temp_env::with_var;
 
     use super::*;
     use crate::flake_ref::FlakeRef;
+    use crate::registry::Registry;
     use crate::url_parser::PARSER_UTIL_BIN_PATH;
 
     /// Ensure that an indirect flake ref serializes without information loss
@@ -196,6 +198,45 @@ mod tests {
         let actual = IndirectRef::from_str("flake:nixpkgs").unwrap();
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn resolves_indirect_ref() {
+        let expected: FlakeRef = "github:flox/runix".parse().unwrap();
+
+        // create a new registry entry,
+        // because the original global/user flake registry is managed outside of the process
+        // so we can not depend on it
+        let mut registry = Registry::default();
+        registry.set("testref", expected.clone());
+
+        // write registry to a file
+        let tempdir = tempfile::tempdir().unwrap();
+        let registry_path = tempdir.path().join("registry.json");
+        std::fs::write(
+            &registry_path,
+            serde_json::to_string_pretty(&registry).unwrap(),
+        )
+        .unwrap();
+
+        // set `flake-registry` config value to our manaaged config
+        // and resolve the `test` entry
+        // and expect to get the same entry we set to the registry above
+        with_var(
+            "NIX_CONFIG",
+            Some(format!(
+                "flake-registry = {}",
+                registry_path.to_string_lossy()
+            )),
+            || {
+                let actual = IndirectRef::from_str("flake:testref")
+                    .unwrap()
+                    .resolve()
+                    .unwrap();
+
+                assert_eq!(actual, expected);
+            },
+        )
     }
 
     #[test]


### PR DESCRIPTION
[resolve-flakeref-to-gitref](https://github.com/flox/runix/tree/resolve-flakeref-to-gitref) is missing a test.

Making a PR for visibility, as this introduces `temp-env` as a dev dependency to isolate environment variables.

All tests are run in the same process, so changing environment variables affects all tests.
While this is the first and for now only test that makes use of environment variables in an obvious way, I'd prefer keeping possible the impact on other tests as low as possible.
Also with parser-util and possibly more tools like it to come that might be affected by the process' environment this can serve as an example for future test cases