### PR TITLE
Revert "feat: support selecting outputs with flake attribute installa…

### DIFF
--- a/crates/runix/src/url_parser.rs
+++ b/crates/runix/src/url_parser.rs
@@ -241,23 +241,12 @@ where
 }
 
 /// The possible flake output types
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum InstallableOutputs {
-    #[default]
-    Default,
     All,
+    Default,
     Selected(Vec<String>),
-}
-
-impl InstallableOutputs {
-    pub fn as_url_suffix(&self) -> String {
-        match self {
-            InstallableOutputs::Default => String::new(),
-            InstallableOutputs::All => "^*".to_string(),
-            InstallableOutputs::Selected(ref outputs) => format!("^{}", outputs.join(",")),
-        }
-    }
 }
 
 /// A flake reference that has been parsed by Nix


### PR DESCRIPTION
This reverts commit d1ba2e30123f8cc340f22284df0c0c54dd2dd2b1 since `flox` currently can't be built with this commit.