### PR TITLE
Add FlakeUpdate command

### DIFF
--- a/crates/runix/src/command.rs
+++ b/crates/runix/src/command.rs
@@ -121,6 +121,23 @@ impl TypedCommand for FlakeMetadata {
     type Output = crate::flake_metadata::FlakeMetadata;
 }
 
+/// `nix flake update` Command
+#[derive(Debug, Default, Clone)]
+pub struct FlakeUpdate {
+    pub eval: EvaluationArgs,
+    pub flake: FlakeArgs,
+    pub flake_ref: Option<FlakeRefArg>,
+}
+
+impl NixCliCommand for FlakeUpdate {
+    type Own = Option<FlakeRefArg>;
+
+    const EVAL_ARGS: Group<Self, EvaluationArgs> = Some(|d| d.eval.clone());
+    const FLAKE_ARGS: Group<Self, FlakeArgs> = Some(|d| d.flake.clone());
+    const OWN_ARGS: Group<Self, Self::Own> = Some(|d| d.flake_ref.clone());
+    const SUBCOMMAND: &'static [&'static str] = &["flake", "update"];
+}
+
 /// `nix develop` Command
 #[derive(Debug, Default, Clone)]
 pub struct Develop {


### PR DESCRIPTION
Closes #47.

I basically just copied and pasted the `FlakeMetadata` implementation. I imagine at some point the flake subcommands might be refactored into their own namespace, but it seems appropriate to just submit the simplest PR first.

As a side-node: As I was testing, I needed to have the `PARSER_UTIL_BIN` env var set to build successfully. Is this binary dependency new since the latest released version? I was able to get it working by snooping around your nix files, but it seems like it might be somewhat of a barrier to adoption. Maybe it could at least be discussed in the readme.

Let me know if you'd like any changes to the PR.

Thanks,
Oliver