### PR TITLE
fix: no_link typo

### DIFF
--- a/crates/runix/src/arguments/mod.rs
+++ b/crates/runix/src/arguments/mod.rs
@@ -92,7 +92,7 @@ impl Flag for NoLink {
 #[derive(Debug, Default, Clone, ToArgs)]
 pub struct BuildArgs {
     pub out_link: Option<OutLink>,
-    pub no_link: Option<Bundler>,
+    pub no_link: Option<NoLink>,
 }
 
 /// `nix develop` options


### PR DESCRIPTION
Unless I'm missing something I think this was just a copy paste error