### PR TITLE
chore: add note that runix is not maintained

### DIFF
--- a/crates/runix/README.md
+++ b/crates/runix/README.md
@@ -1,5 +1,7 @@
 # runix
 
+⚠️ runix is currently not actively maintained.
+
 A typesafe interface to the [nix](https://github.com/nixos/nix) CLI.
 
 *by [flox](https://github.com/flox)*


### PR DESCRIPTION
flox/flox has started using the Nix library via a C++ binary.